### PR TITLE
Add assertions for data validation across parser and task operations

### DIFF
--- a/src/main/java/duke/Parser.java
+++ b/src/main/java/duke/Parser.java
@@ -2,6 +2,7 @@ package duke;
 
 public class Parser {
     public static Command parseCommand(String input) {
+        assert !input.isEmpty();
         String command = input.trim().split(" ")[0].toUpperCase();
         try {
             return Command.getEnumCommand(command);
@@ -12,6 +13,7 @@ public class Parser {
     }
 
     public static String parseArguments(String input) {
+        assert !input.isEmpty();
         String[] parts = input.split(" ", 2);
         return parts.length < 2 ? "" : parts[1].trim();
     }

--- a/src/main/java/duke/Storage.java
+++ b/src/main/java/duke/Storage.java
@@ -18,6 +18,7 @@ public class Storage {
     private Scanner fileScanner;
 
     public Storage(String path) {
+        assert !path.isEmpty();
         this.file = new File(path);
 
         try {

--- a/src/main/java/duke/ui/AstridGlowspell.java
+++ b/src/main/java/duke/ui/AstridGlowspell.java
@@ -52,6 +52,7 @@ public class AstridGlowspell {
      * @param index task number in list (1-indexed)
      */
     private String mark(int index) {
+        assert index > 0;
         try {
             if (index > this.tasks.size()) {
                 throw new TaskNotFoundException();
@@ -71,6 +72,7 @@ public class AstridGlowspell {
      * @param index task number in list (1-indexed)
      */
     private String unmark(int index) {
+        assert index > 0;
         try {
             if (index > tasks.size()) {
                 throw new TaskNotFoundException();
@@ -86,6 +88,7 @@ public class AstridGlowspell {
     }
 
     private String find(String keyword) {
+        assert !keyword.isEmpty();
         TaskList res = tasks.find(keyword);
         return ui.find(res);
     }
@@ -96,6 +99,7 @@ public class AstridGlowspell {
      * @param index task number in list (1-indexed)
      */
     private String delete(int index) {
+        assert index > 0;
         try {
             if (index > tasks.size()) {
                 throw new TaskNotFoundException();


### PR DESCRIPTION
Parser and task management functions accept input values without explicit validation.

Unchecked inputs can lead to runtime errors or undefined behavior, such as empty strings in the parser or negative indices when marking/unmarking tasks.

Let's add assertions to validate input data, ensuring parser strings are not empty and task indices are zero or positive.

Assertions enforce correctness at runtime and make assumptions about input explicit, catching invalid states early in development. If you want, I can also make a slightly shorter, punchier version suitable for teams that prefer concise commit messages. Do you want me to do that?